### PR TITLE
goopax_draw include path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,7 @@ if (GOOPAX_DRAW_WITH_OPENGL OR GOOPAX_DRAW_WITH_METAL AND NOT GOOPAX_DEBUG)
 endif()
 
 add(deep-zoom-mandelbrot Boost::system goopax_draw)
-add(gather)
+add(gather goopax_typedefs)
 add(mandelbrot goopax_draw)
 add(fft opencv goopax_draw)
 add(svm-pingpong goopax_typedefs)

--- a/src/common/draw/CMakeLists.txt
+++ b/src/common/draw/CMakeLists.txt
@@ -11,6 +11,8 @@ if (GOOPAX_DEBUG)
 else()
   target_compile_definitions(goopax_typedefs INTERFACE -DGOOPAX_DEBUG=0)
 endif()
+target_include_directories(goopax_typedefs SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
 
 
 if (TARGET SDL3::SDL3 AND TARGET Eigen3::Eigen)

--- a/src/common/draw/window_sdl.cpp
+++ b/src/common/draw/window_sdl.cpp
@@ -12,7 +12,7 @@ void print_properties(unsigned int props)
 {
     SDL_EnumerateProperties(
         props,
-        [](void* userdata, SDL_PropertiesID props, const char* name) {
+        [](void*, SDL_PropertiesID props, const char* name) {
             cout << name << ": ";
 
             auto type = SDL_GetPropertyType(props, name);

--- a/src/common/particle.hpp
+++ b/src/common/particle.hpp
@@ -64,7 +64,7 @@ struct particle_renderer
     particle_renderer(sdl_window_metal& window0)
         : window(window0)
     {
-        device = MTLCreateSystemDefaultDevice();
+        device = static_cast<id<MTLDevice>>(window.device.get_device_ptr());
 
         NSString* progSrc = @"\
 	struct VertexOut {\

--- a/src/deep-zoom-mandelbrot.cpp
+++ b/src/deep-zoom-mandelbrot.cpp
@@ -3,10 +3,10 @@
    Mandelbrot example program with deep zoom capability.
  */
 
-#include "common/draw/window_sdl.h"
 #include <SDL3/SDL_main.h>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #include <chrono>
+#include <draw/window_sdl.h>
 #include <goopax_extra/struct_types.hpp>
 
 using namespace goopax;

--- a/src/fft.cpp
+++ b/src/fft.cpp
@@ -4,8 +4,8 @@
    Applies fourier transforms to video or camera images to make them unsharp.
  */
 
-#include "common/draw/window_sdl.h"
 #include <SDL3/SDL_main.h>
+#include <draw/window_sdl.h>
 #include <goopax_extra/fft.hpp>
 #include <opencv2/opencv.hpp>
 

--- a/src/gather.cpp
+++ b/src/gather.cpp
@@ -3,7 +3,7 @@
    Demonstrates the use of the gather mechanism to get return values from kernel calls.
  */
 
-#include "common/draw/types.h"
+#include <draw/types.h>
 #include <goopax>
 #include <goopax_extra/output.hpp>
 #include <goopax_extra/random.hpp>

--- a/src/mandelbrot.cpp
+++ b/src/mandelbrot.cpp
@@ -3,9 +3,9 @@
    Mandelbrot example
  */
 
-#include "common/draw/window_sdl.h"
 #include <SDL3/SDL_main.h>
 #include <chrono>
+#include <draw/window_sdl.h>
 #include <goopax_extra/struct_types.hpp>
 
 using namespace goopax;

--- a/src/matmul.cpp
+++ b/src/matmul.cpp
@@ -4,9 +4,9 @@
    use of tensor core hardware acceleration
  */
 
-#include "common/draw/types.h"
 #include <cassert>
 #include <chrono>
+#include <draw/types.h>
 #include <goopax>
 #include <goopax_extra/param.hpp>
 #include <goopax_extra/random.hpp>

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -3,10 +3,10 @@
    Simple N-body example program
  */
 
-#include "common/draw/window_sdl.h"
 #include "common/particle.hpp"
 #include <SDL3/SDL_main.h>
 #include <chrono>
+#include <draw/window_sdl.h>
 #include <random>
 using std::chrono::steady_clock;
 


### PR DESCRIPTION
Exporting the include path, so that the goopax_draw library can be imported from other locations.